### PR TITLE
Fix category name missing on item updates

### DIFF
--- a/lib/models/Item.dart
+++ b/lib/models/Item.dart
@@ -59,6 +59,7 @@ class Item {
     String? name,
     int? quantity,
     int? category_id,
+    String? categoryName,
     bool? isChecked,
   }) {
     return Item(
@@ -66,6 +67,7 @@ class Item {
       name: name ?? this.name,
       quantity: quantity ?? this.quantity,
       category_id: category_id ?? this.category_id,
+      categoryName: categoryName ?? this.categoryName,
       isChecked: isChecked ?? this.isChecked,
     );
   }

--- a/lib/presentation/widgets/widgetsBackpack/backpack_card.dart
+++ b/lib/presentation/widgets/widgetsBackpack/backpack_card.dart
@@ -161,6 +161,7 @@ class CategoryCard extends ConsumerWidget {
                     quantity: quantity,
                     isChecked: false,
                     category_id: categoryId,
+                    categoryName: title,
                   ));
                 }
 

--- a/lib/providers/item_notifier.dart
+++ b/lib/providers/item_notifier.dart
@@ -49,9 +49,13 @@ class ItemNotifier extends StateNotifier<AsyncValue<List<Item>>> {
     try {
       final updatedItem = await ref.read(itemApiProvider).updateItem(item);
 
+      // Preserve categoryName if API response doesn't include it
+      final itemWithCategory =
+          updatedItem.copyWith(categoryName: item.categoryName);
+
       final updatedList = (state.value ?? [])
           .map((existingItem) =>
-              existingItem.id == item.id ? updatedItem : existingItem)
+              existingItem.id == item.id ? itemWithCategory : existingItem)
           .toList();
 
       state = AsyncData(updatedList);
@@ -71,9 +75,15 @@ class ItemNotifier extends StateNotifier<AsyncValue<List<Item>>> {
       // 2. Enviar al backend
       final result = await ref.read(itemApiProvider).updateItem(updatedItem);
 
+      // Mantener el nombre de categoría local si la respuesta no lo incluye
+      final itemWithCategory =
+          result.copyWith(categoryName: item.categoryName);
+
       // 3. Reconstruir la lista con el nuevo ítem actualizado
       final updatedList = (state.value ?? []).map((existingItem) {
-        return existingItem.id == result.id ? result : existingItem;
+        return existingItem.id == itemWithCategory.id
+            ? itemWithCategory
+            : existingItem;
       }).toList();
 
       // 4. Actualizar el estado


### PR DESCRIPTION
## Summary
- keep `categoryName` when creating copies of Item
- ensure updated items retain their category names in ItemNotifier
- include category name when adding a new item

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684941eefe08832681776957e39e4d18